### PR TITLE
Friday bugs should be a part of the Monday triage

### DIFF
--- a/ustriage/ustriage.py
+++ b/ustriage/ustriage.py
@@ -193,7 +193,7 @@ def reverse_auto_date_range(start, end):
         return "Monday triage"
 
     if start == end:
-        if start_weekday in [5, 6]:
+        if start_weekday in [4, 5, 6]:
             return None  # weekend: process not specified
 
         # must be regular day triage

--- a/ustriage/ustriage_test.py
+++ b/ustriage/ustriage_test.py
@@ -45,6 +45,7 @@ def test_auto_date_range_weekend(today, keyword):
     ('2019-05-07', '2019-05-06', None),  # reverse range definition
     ('2019-05-06', '2019-05-09', None),  # more than two days apart
     ('2019-05-18', '2019-05-18', None),  # Saturday
+    ('2021-04-16', '2021-04-16', None),  # Friday
 ])
 def test_reverse_auto_date_range(start, end, expected):
     """Test reverse date range."""


### PR DESCRIPTION
If ustriage is run on a Saturday, it'd result in the
following traceback:
```
day = ['Tuesday', 'Wednesday', 'Thursday', 'Friday'][start_weekday]
IndexError: list index out of range
```
because it looks for bugs on Friday, which should
essentially be a part of the Monday triage.


Signed-off-by: Utkarsh Gupta <<utkarsh@debian.org>>