### PR TITLE
Flags - General readability and marking recent updates for tag/list searches

### DIFF
--- a/ustriage/task.py
+++ b/ustriage/task.py
@@ -10,6 +10,7 @@ Joshua Powers <josh.powers@canonical.com>
 """
 
 from functools import lru_cache
+from datetime import datetime, timedelta, timezone
 
 
 DISTRIBUTION_RESOURCE_TYPE_LINK = (
@@ -84,6 +85,12 @@ class Task:
 
     @property
     @lru_cache()
+    def date_one_week_ago(self):
+        """Time ~ one week ago - no recalcualtion."""
+        return datetime.now(timezone.utc) - timedelta(days=7)
+
+    @property
+    @lru_cache()
     def importance(self):
         """Return importance as returned by launchpad."""
         return self.obj.importance
@@ -133,9 +140,10 @@ class Task:
         return ' '.join(self.title.split(' ')[start_field:]).replace('"', '')
 
     def set_flags(self):
-        return '%s%s' % (
+        return '%s%s%s' % (
             '*' if self.subscribed else '',
             '+' if self.last_activity_ours else '',
+            'U' if self.date_last_updated > self.date_one_week_ago else '',
         )
 
     def compose_pretty(self, shortlinks=True, extended=False):
@@ -157,7 +165,7 @@ class Task:
 
         flags = self.set_flags()
 
-        text = '%s - %3s %-12s %-19s' % (
+        text = '%s - %3s %-13s %-19s' % (
             bug_url,
             flags,
             ('%s' % self.status),
@@ -184,7 +192,7 @@ class Task:
 
         flags = self.set_flags()
 
-        text = '%s - %3s %-12s %-19s' % (
+        text = '%s - %3s %-13s %-19s' % (
             dupprefix,
             flags,
             ('%s' % self.status),

--- a/ustriage/task.py
+++ b/ustriage/task.py
@@ -132,6 +132,12 @@ class Task:
         }[self.obj.target.resource_type_link]
         return ' '.join(self.title.split(' ')[start_field:]).replace('"', '')
 
+    def set_flags(self):
+        return '%s%s' % (
+            '*' if self.subscribed else '',
+            '+' if self.last_activity_ours else '',
+        )
+
     def compose_pretty(self, shortlinks=True, extended=False):
         """Compose a printable line of relevant information."""
         if shortlinks:
@@ -149,14 +155,12 @@ class Task:
             )
             bug_url = format_string % self.url
 
-        flags = '%s%s' % (
-            '*' if self.subscribed else '',
-            '+' if self.last_activity_ours else '',
-        )
+        flags = self.set_flags()
 
-        text = '%s - %-16s %-19s' % (
+        text = '%s - %3s %-12s %-19s' % (
             bug_url,
-            ('%s(%s)' % (flags, self.status)),
+            flags,
+            ('%s' % self.status),
             ('[%s]' % truncate_string(self.src, 16))
         )
         if extended:
@@ -178,14 +182,12 @@ class Task:
         format_string = ('%-' + duplen + 's')
         dupprefix = format_string % 'also:'
 
-        flags = '%s%s' % (
-            '*' if self.subscribed else '',
-            '+' if self.last_activity_ours else '',
-        )
+        flags = self.set_flags()
 
-        text = '%s - %-16s %-19s' % (
+        text = '%s - %3s %-12s %-19s' % (
             dupprefix,
-            ('%s(%s)' % (flags, self.status)),
+            flags,
+            ('%s' % self.status),
             ('[%s]' % truncate_string(self.src, 16))
         )
         if extended:

--- a/ustriage/task.py
+++ b/ustriage/task.py
@@ -135,13 +135,13 @@ class Task:
 
     def get_flags(self):
         """Get flags representing the status of the task."""
-        flags = '%s%s' % (
-            '*' if self.subscribed else '',
-            '+' if self.last_activity_ours else '',
-        )
-        if self.AGE:
-            if self.date_last_updated > self.AGE:
-                flags += 'U'
+        flags = ''
+        if self.subscribed:
+            flags += '*'
+        if self.last_activity_ours:
+            flags += '+'
+        if self.AGE and self.date_last_updated > self.AGE:
+            flags += 'U'
         return flags
 
     def compose_pretty(self, shortlinks=True, extended=False):

--- a/ustriage/ustriage.py
+++ b/ustriage/ustriage.py
@@ -756,12 +756,12 @@ def launch():
                         dest='extended_format',
                         help='Do Display bugs in extended format which adds'
                              ' date-last-updated, importance and assignee')
-    parser.add_argument('-A', '--age',
-                        default=-1,
+    parser.add_argument('-F', '--flag-recent',
+                        default=False,
                         type=int,
                         dest='age',
-                        help='Mark bugs older than this many days (default'
-                             ' disabled in triage, 7 days in '
+                        help='Mark bugs touched more recently than this many'
+                             ' days (default disabled in triage, 7 days in '
                              ' tag/subscription search)')
 
     args = parser.parse_args()

--- a/ustriage/ustriage.py
+++ b/ustriage/ustriage.py
@@ -596,6 +596,7 @@ def main(date_range=None, debug=False, open_browser=None,
     logging.info('Symbols:')
     logging.info('\'*\': %s is directly subscribed', lpname)
     logging.info('\'+\': last bug activity is ours')
+    logging.info('\'U\': Updated in the last 7 days')
     logging.info('Please be patient, this can take a few minutes...')
 
     if show_tagged:

--- a/ustriage/ustriage.py
+++ b/ustriage/ustriage.py
@@ -774,22 +774,17 @@ def launch():
     date_range = {'start': args.start_date,
                   'end': args.end_date}
 
-    if args.age == -1:
-        if args.show_subscribed or args.show_tagged:
-            age = 7
-        else:
-            age = False
-    else:
-        age = args.age
-    if age:
-        Task.AGE = datetime.now(timezone.utc) - timedelta(days=age)
+    if args.age is False and (args.show_subscribed or args.show_tagged):
+        args.age = 7
+    if args.age is not False:
+        Task.AGE = datetime.now(timezone.utc) - timedelta(days=args.age)
 
     main(date_range, args.debug, open_browser,
          args.lpname, args.bugsubscriber, not args.fullurls,
          args.activitysubscribers, expiration, args.show_no_triage,
          args.show_tagged, args.show_subscribed, args.limit_subscribed,
          blacklist=None if args.no_blacklist else PACKAGE_BLACKLIST,
-         tags=[args.tag], extended=args.extended_format, age=age)
+         tags=[args.tag], extended=args.extended_format, age=args.age)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hi,
the flags are already useful, but not always great to read as they shift the status a bit if the amount of flags present changes. This PR improves the layout and then uses the flags to help our new use case around tag/list checking by allowing to mark bugs updated in a certain time via a new flag.

triage has no use of the age, so it defaults to not bother with it

old
```
Bugs last updated between 2021-12-03 (Friday) and 2021-12-05 (Sunday) inclusive
Date range identified as: "Monday triage"
Found 21 bugs
LP: #1945960 - *+(Triaged)      [net-snmp]          - net-snmp: Fail to build against OpenSSL 3.0
LP: #1946831 - +(In Progress)   [apache2]           - Merge apache2 from Debian unstable for 22.04
LP: #1951476 - *+(In Progress)  [apache2]           - apache2: mod_ssl fails to load with OpenSSL 3.0
LP: #1827367 - (New)            [rabbitmq-server]   - rabbitmq-server outdated

```

new
```
Bugs last updated between 2021-12-03 (Friday) and 2021-12-05 (Sunday) inclusive
Date range identified as: "Monday triage"
Found 21 bugs
LP: #1945960 -  *+ Triaged       [net-snmp]          - net-snmp: Fail to build against OpenSSL 3.0
LP: #1946831 -   + In Progress   [apache2]           - Merge apache2 from Debian unstable for 22.04
LP: #1951476 -  *+ In Progress   [apache2]           - apache2: mod_ssl fails to load with OpenSSL 3.0
LP: #1827367 -     New           [rabbitmq-server]   - rabbitmq-server outdated

```

list/tag checking usually wants to know last updates, and defaults to 7 days

old
```
Found 21 bugs
LP: #1749393 - +(Fix Committed) [qemu]              01.12.21 Medium     => paelzer    - sbrk() not working under qemu-user with a PIE-compiled bina…
LP: #1832182 - +(Triaged)       [apache2]           27.10.21 High       => bryce      - systemd unable to detect running apache if invoked via apac…
LP: #1945763 - +(Fix Committed) [dovecot]           30.11.21 High       => bryce      - dovecot: Fail to build against OpenSSL 3.0
LP: #1945960 - +(Triaged)       [net-snmp]          03.12.21 High       => sergiodj   - net-snmp: Fail to build against OpenSSL 3.0
LP: #1945980 - +(Fix Committed) [openvpn]           01.12.21 Undecided  => bryce      - openvpn: Fail to build against OpenSSL 3.0
LP: #1946189 - +(Confirmed)     [python-cryptogr…]  10.11.21 Undecided                - python-cryptography: Fail to build against OpenSSL 3.0
LP: #1951408 - +(In Progress)   [glusterfs]         26.11.21 Undecided  => ahasenack  - FTBFS on armhf (and mips) - undefined reference to `_uatomi…
```

new
```
Bugs tagged "server-next" and subscribed "ubuntu-server"
Found 21 bugs
LP: #1749393 -  +U Fix Committed [qemu]              01.12.21 Medium     => paelzer    - sbrk() not working under qemu-user with a PIE-compiled bina…
LP: #1832182 -   + Triaged       [apache2]           27.10.21 High       => bryce      - systemd unable to detect running apache if invoked via apac…
LP: #1945763 -  +U Fix Committed [dovecot]           30.11.21 High       => bryce      - dovecot: Fail to build against OpenSSL 3.0
LP: #1945960 -  +U Triaged       [net-snmp]          03.12.21 High       => sergiodj   - net-snmp: Fail to build against OpenSSL 3.0
LP: #1945980 -  +U Fix Committed [openvpn]           01.12.21 Undecided  => bryce      - openvpn: Fail to build against OpenSSL 3.0
LP: #1946189 -   + Confirmed     [python-cryptogr…]  10.11.21 Undecided                - python-cryptography: Fail to build against OpenSSL 3.0
LP: #1951408 -   + In Progress   [glusterfs]         26.11.21 Undecided  => ahasenack  - FTBFS on armhf (and mips) - undefined reference to `_uatomi…
```