### PR TITLE
Improve weekly bug-checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,3 +149,8 @@ This shows the most recent and the oldest 20 entries that are `ubuntu-server` su
 ```bash
 ustriage --no-show-triage --show-subscribed --show-subscribed-max 20 --extended-format
 ```
+
+Note: The file format on the save/compare feature isn't well defined, do
+consider it experimental as it might change without warning. OTOH right now
+being just a yaml list of bug numbers makes it very easy to - if needed - modify
+it.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ ustriage 2016-09-10
 
 ### Two Date Arguments
 
-If two dates are given then all the bugs found on those days and between (fully inclusive) wil be found. For example, the following, finds all bugs last modified on the 10th, 11th, and 12th of September:
+If two dates are given then all the bugs found on those days and between (fully inclusive) will be found. For example, the following, finds all bugs last modified on the 10th, 11th, and 12th of September:
 
 ```bash
 ustriage 2016-09-10 2016-09-12
@@ -98,7 +98,7 @@ Those are "date of the last update", "importance" and "assignee" (if there is an
 ### Further options and use cases of bug expiration
 
 The expiration is defined as 60 days of inactivity in server-next tagged bugs, and 180 days for the other ubuntu-server subscribed bugs.
-These durations as well as the tag it considers for the "active" list can be tuned via the arguments, --expire-tagged, --expire and --tag.
+These duration's as well as the tag it considers for the "active" list can be tuned via the arguments, --expire-tagged, --expire and --tag.
 This can be combined with a custom bug subscriber to be useful outside of the server team triage.
 So the following example for example will list any bugs subscribed by hardcoredev which are inactive for 5 or more days with the tag super-urgent.
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Those are "date of the last update", "importance" and "assignee" (if there is an
 ### Further options and use cases of bug expiration
 
 The expiration is defined as 60 days of inactivity in server-next tagged bugs, and 180 days for the other ubuntu-server subscribed bugs.
-These duration's as well as the tag it considers for the "active" list can be tuned via the arguments, --expire-tagged, --expire and --tag.
+These durations as well as the tag it considers for the "active" list can be tuned via the arguments, --expire-tagged, --expire and --tag.
 This can be combined with a custom bug subscriber to be useful outside of the server team triage.
 So the following example for example will list any bugs subscribed by hardcoredev which are inactive for 5 or more days with the tag super-urgent.
 
@@ -120,7 +120,7 @@ It turned out to be a common need to identify differences since the last
 meeting. Since the situation in launchpad might have changed (dropped tag,
 closed the bug, assigned to other teams, changed subscription) and not all of
 them can be detected from launchpad-api after the fast ustriage now also
-provides the option to save and compare a list of stored bugs
+provides the option to save and compare a list of stored bugs.
 On a usual run checking tagged bugs one can add -S to save the reported
 bugs to a file. It is recommended to include the timestamp like:
 `-S ~/savebugs/todo-$(date -I'seconds').yaml`

--- a/README.md
+++ b/README.md
@@ -116,8 +116,29 @@ ubuntu-server as our current two levels of [bug tracking](https://github.com/can
 Thereby one can easily check all our current subscribed and `server-next`
 tagged bugs (or any other tag via `--tag`):
 
+It turned out to be a common need to identify differences since the last
+meeting. Since the situation in launchpad might have changed (dropped tag,
+closed the bug, assigned to other teams, changed subscription) and not all of
+them can be detected from launchpad-api after the fast ustriage now also
+provides the option to save and compare a list of stored bugs
+On a usual run checking tagged bugs one can add -S to save the reported
+bugs to a file. It is recommended to include the timestamp like:
+`-S ~/savebugs/todo-$(date -I'seconds').yaml`
+
+On later runs ustriage can compare the current set of bugs with any such stored
+list and report new bugs (flag "N") and reports a list of cases gone from the
+report.
+
+Furthermore a common need is to see which bugs have had any updates recently.
+The option `--flag-recent` allows to specify an amount of days (we use 6
+usually) that will make a bug touched in that period get an updated flag "U"
+in the report.
+
+All that combined means that we usually run two command for our weekly checks
+
 ```bash
-ustriage --no-show-triage --show-tagged --extended-format
+ustriage --no-show-triage --extended --show-tagged --tag server-todo --flag-recent 6 -S ~/savebugs/todo-$(date -I'seconds').yaml -C ~/savebugs/todo-2022-02-01T12:45:10+01:00.yaml
+ustriage --no-show-triage --extended --show-tagged --tag server-next --flag-recent 6 -S ~/savebugs/next-$(date -I'seconds').yaml -C ~/savebugs/next-2022-02-01T12:45:16+01:00.yaml
 ```
 
 Or our bigger backlog of any open `ubuntu-server` (or any other via --lpname)

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -32,3 +32,4 @@ parts:
         stage-packages:
             - python3-dateutil
             - python3-launchpadlib
+            - python3-yaml

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ deps =
     pytest
     pytest-cov
     python-dateutil
+    pyyaml
     launchpadlib
 commands =
     py.test --cov ustriage ustriage

--- a/ustriage/task.py
+++ b/ustriage/task.py
@@ -136,12 +136,12 @@ class Task:
     def get_flags(self):
         """Get flags representing the status of the task."""
         flags = ''
-        if self.subscribed:
-            flags += '*'
-        if self.last_activity_ours:
-            flags += '+'
-        if self.AGE and self.date_last_updated > self.AGE:
+        flags += '*' if self.subscribed else ' '
+        flags += '+' if self.last_activity_ours else ' '
+        if (self.AGE and self.date_last_updated > self.AGE):
             flags += 'U'
+        else:
+            flags += ' '
         return flags
 
     def compose_pretty(self, shortlinks=True, extended=False):

--- a/ustriage/task.py
+++ b/ustriage/task.py
@@ -134,7 +134,10 @@ class Task:
         return ' '.join(self.title.split(' ')[start_field:]).replace('"', '')
 
     def get_flags(self, newbug=False):
-        """Get flags representing the status of the task."""
+        """Get flags representing the status of the task.
+
+        Note: This has to stay a fixed length string to maintain the layout
+        """
         flags = ''
         flags += '*' if self.subscribed else ' '
         flags += '+' if self.last_activity_ours else ' '
@@ -162,7 +165,7 @@ class Task:
             )
             bug_url = format_string % self.url
 
-        text = '%s - %4s %-13s %-19s' % (
+        text = '%s - %s %-13s %-19s' % (
             bug_url,
             self.get_flags(newbug),
             ('%s' % self.status),
@@ -187,7 +190,7 @@ class Task:
         format_string = ('%-' + duplen + 's')
         dupprefix = format_string % 'also:'
 
-        text = '%s - %4s %-13s %-19s' % (
+        text = '%s - %s %-13s %-19s' % (
             dupprefix,
             self.get_flags(),
             ('%s' % self.status),

--- a/ustriage/task.py
+++ b/ustriage/task.py
@@ -162,11 +162,9 @@ class Task:
             )
             bug_url = format_string % self.url
 
-        flags = self.get_flags(newbug)
-
         text = '%s - %4s %-13s %-19s' % (
             bug_url,
-            flags,
+            self.get_flags(newbug),
             ('%s' % self.status),
             ('[%s]' % truncate_string(self.src, 16))
         )
@@ -189,11 +187,9 @@ class Task:
         format_string = ('%-' + duplen + 's')
         dupprefix = format_string % 'also:'
 
-        flags = self.get_flags()
-
         text = '%s - %4s %-13s %-19s' % (
             dupprefix,
-            flags,
+            self.get_flags(),
             ('%s' % self.status),
             ('[%s]' % truncate_string(self.src, 16))
         )

--- a/ustriage/task.py
+++ b/ustriage/task.py
@@ -133,7 +133,7 @@ class Task:
         }[self.obj.target.resource_type_link]
         return ' '.join(self.title.split(' ')[start_field:]).replace('"', '')
 
-    def get_flags(self):
+    def get_flags(self, newbug=False):
         """Get flags representing the status of the task."""
         flags = ''
         flags += '*' if self.subscribed else ' '
@@ -142,9 +142,10 @@ class Task:
             flags += 'U'
         else:
             flags += ' '
+        flags += 'N' if newbug else ' '
         return flags
 
-    def compose_pretty(self, shortlinks=True, extended=False):
+    def compose_pretty(self, shortlinks=True, extended=False, newbug=False):
         """Compose a printable line of relevant information."""
         if shortlinks:
             format_string = (
@@ -161,9 +162,9 @@ class Task:
             )
             bug_url = format_string % self.url
 
-        flags = self.get_flags()
+        flags = self.get_flags(newbug)
 
-        text = '%s - %3s %-13s %-19s' % (
+        text = '%s - %4s %-13s %-19s' % (
             bug_url,
             flags,
             ('%s' % self.status),
@@ -190,7 +191,7 @@ class Task:
 
         flags = self.get_flags()
 
-        text = '%s - %3s %-13s %-19s' % (
+        text = '%s - %4s %-13s %-19s' % (
             dupprefix,
             flags,
             ('%s' % self.status),

--- a/ustriage/ustriage.py
+++ b/ustriage/ustriage.py
@@ -811,11 +811,11 @@ def launch():
     parser.add_argument('-S', '--save-tagged-bugs',
                         default=False,
                         dest='filename_save',
-                        help='Save the list of reported tagged bugs to %file')
+                        help='Save the list of reported tagged bugs to file')
     parser.add_argument('-C', '--compare-tagged-bugs-to',
                         default=False,
                         dest='filename_compare',
-                        help='Compare the reported tagged bugs to %file')
+                        help='Compare the reported tagged bugs to file')
 
     args = parser.parse_args()
 

--- a/ustriage/ustriage.py
+++ b/ustriage/ustriage.py
@@ -273,7 +273,7 @@ def parse_dates(start, end=None):
 
 def print_bugs(tasks, open_in_browser=False, shortlinks=True, blacklist=None,
                limit_subscribed=None, oder_by_date=False, is_sorted=False,
-               extended=False, filename_save=False, filename_compare=False):
+               extended=False, filename_save=None, filename_compare=None):
     """Print the tasks in a clean-ish format."""
     blacklist = blacklist or []
 
@@ -306,7 +306,7 @@ def print_bugs(tasks, open_in_browser=False, shortlinks=True, blacklist=None,
 
     opened = False
     former_bugs = []
-    if filename_compare:
+    if filename_compare is not None:
         with open(filename_compare, "r", encoding='utf-8') as comparebugs:
             former_bugs = yaml.safe_load(comparebugs)
 
@@ -330,12 +330,12 @@ def print_bugs(tasks, open_in_browser=False, shortlinks=True, blacklist=None,
                 time.sleep(5)
         reportedbugs.append(task.number)
 
-    if filename_save:
+    if filename_save is not None:
         with open(filename_save, "w", encoding='utf-8') as savebugs:
             yaml.dump(reportedbugs, stream=savebugs)
         print("Saved reported bugs in %s" % filename_save)
 
-    if filename_compare:
+    if filename_compare is not None:
         closed_bugs = [x for x in former_bugs if x not in reportedbugs]
         logging.info('')
         logging.info('---')
@@ -545,7 +545,7 @@ def report_current_backlog(lpname):
 def print_tagged_bugs(lpname, expiration, date_range, open_browser,
                       shortlinks, blacklist, activitysubscribers,
                       tags, extended,
-                      filename_save=False, filename_compare=False):
+                      filename_save=None, filename_compare=None):
     """Print tagged bugs.
 
     Print tagged bugs, optionally those that have not been
@@ -623,7 +623,7 @@ def main(date_range=None, debug=False, open_browser=None,
          show_no_triage=False, show_tagged=False, show_subscribed=False,
          limit_subscribed=None, blacklist=None, tags=None,
          extended=False, age=False,
-         filename_save=False, filename_compare=False):
+         filename_save=None, filename_compare=None):
     """Connect to Launchpad, get range of bugs, print 'em."""
     if tags is None:
         tags = ["server-next"]
@@ -809,11 +809,11 @@ def launch():
                              ' days (default disabled in triage, 7 days in '
                              ' tag/subscription search)')
     parser.add_argument('-S', '--save-tagged-bugs',
-                        default=False,
+                        default=None,
                         dest='filename_save',
                         help='Save the list of reported tagged bugs to file')
     parser.add_argument('-C', '--compare-tagged-bugs-to',
-                        default=False,
+                        default=None,
                         dest='filename_compare',
                         help='Compare the reported tagged bugs to file')
 


### PR DESCRIPTION
One can save the reported list of tagged bugs like
```
$ ustriage --no-show-triage --extended --show-tagged --tag server-next --flag-recent 6 -S ~/savebugs/next-$(date -I'seconds').yaml
...
Saved reported bugs in /home/paelzer/savebugs/next-2022-02-01T12:45:10+01:00.yaml
```

And the week after (or any time later) one can refer to the old list:
```
$ ustriage --no-show-triage --extended --show-tagged --tag server-next --flag-recent 6 -S ~/savebugs/next-$(date -I'seconds').yaml -C ~/savebugs/next-2022-02-01T12\:45\:10+01\:00.yaml
```

This will mark bugs not yet in last weeks list as "N" for new like
```
LP: #1951490 -  +UN Confirmed     [samba]             27.01.22 High                     - Can't print after update to 4.13
```

And it will add an extra list of bugs that are gone (closed, dropped tag, ...)
```
Bugs gone compared with /home/paelzer/savebugs/next-2022-02-01T12:45:10+01:00.yaml:
Found 3 bugs
LP: #1890230 -   UN Confirmed     [ipxe]              27.01.22 Medium                   - arm64 ipxe package isn't an arm64 build
also:        -   U  Confirmed     [ipxe]                       Medium
also:        -   U  Won't Fix     [ipxe]                       Medium
```

_P.S. While working on this I also improved the flags readability by making each use fix-columns._