### PR TITLE
task: tolerate projects

### DIFF
--- a/ustriage/task.py
+++ b/ustriage/task.py
@@ -24,6 +24,10 @@ SOURCE_PACKAGE_RESOURCE_TYPE_LINK = (
     'https://api.launchpad.net/devel/#source_package'
 )
 
+PROJECT_RESOURCE_TYPE_LINK = (
+    'https://api.launchpad.net/devel/#project'
+)
+
 
 def truncate_string(text, length=20):
     """Truncate string and hint visually if truncated."""
@@ -130,6 +134,7 @@ class Task:
             DISTRIBUTION_RESOURCE_TYPE_LINK: 4,
             DISTRIBUTION_SOURCE_PACKAGE_RESOURCE_TYPE_LINK: 5,
             SOURCE_PACKAGE_RESOURCE_TYPE_LINK: 6,
+            PROJECT_RESOURCE_TYPE_LINK: 7,
         }[self.obj.target.resource_type_link]
         return ' '.join(self.title.split(' ')[start_field:]).replace('"', '')
 


### PR DESCRIPTION
If a bug holds an upstream project as task like bug 1946205 it will break
ustriage when trying to compose the short title missing a known key.

The reason is that the type of it is `https://api.launchpad.net/devel/#project`
which isn't known.

Example:
```
...
  File "ubuntu-server-triage/ustriage/task.py", line 185, in compose_pretty
    text += ' - %s' % truncate_string(self.short_title, 60)
  File "ubuntu-server-triage/ustriage/task.py", line 133, in short_title
    start_field = {
KeyError: 'https://api.launchpad.net/devel/#project'
```

Make `https://api.launchpad.net/devel/#project` known to avoid that

Some fields like priority might not be set on that type, but it works just
fine reporting that:
```
LP: #1946205 -   U  Unknown       [Squid:]            11.02.22 Unknown                  - build against OpenSSL 3.0
```