### PR TITLE
Improve information for our weekly use on bug-housekeeping

### DIFF
--- a/ustriage/task.py
+++ b/ustriage/task.py
@@ -83,6 +83,12 @@ class Task:
 
     @property
     @lru_cache()
+    def tags(self):
+        """List of the Bugs tags."""
+        return self.obj.bug.tags
+
+    @property
+    @lru_cache()
     def date_last_updated(self):
         """Last update as datetime returned by launchpad."""
         return self.obj.bug.date_last_updated
@@ -151,6 +157,12 @@ class Task:
         else:
             flags += ' '
         flags += 'N' if newbug else ' '
+        if 'verification-needed' in self.tags:
+            flags += 'v'
+        elif 'verification-done' in self.tags:
+            flags += 'V'
+        else:
+            flags += ' '
         return flags
 
     def compose_pretty(self, shortlinks=True, extended=False, newbug=False):

--- a/ustriage/task.py
+++ b/ustriage/task.py
@@ -198,28 +198,14 @@ class Task:
         text += ' - %s' % truncate_string(self.short_title, 60)
         return text
 
-    def compose_dup(self, shortlinks=True, extended=False):
+    def compose_dup(self, extended=False):
         """Compose a printable line of reduced information for a dup."""
-        if shortlinks:
-            duplen = str(self.BUG_NUMBER_LENGTH + len(self.SHORTLINK_ROOT))
-        else:
-            duplen = str(self.BUG_NUMBER_LENGTH + len(self.LONG_URL_ROOT))
-        format_string = ('%-' + duplen + 's')
-        dupprefix = format_string % 'also:'
-
-        text = '%s - %s %-13s %-19s' % (
-            dupprefix,
-            self.get_flags(),
+        text = '%s,%s' % (
             ('%s' % self.status),
-            ('[%s]' % truncate_string(self.src, 16))
+            ('%s' % truncate_string(self.src, 16))
         )
-        if extended:
-            text += ' %8s %-10s %-13s' % (
-                "",
-                self.importance,
-                ('' if not self.assignee
-                 else '=> %s' % truncate_string(self.assignee, 9))
-            )
+        if extended and self.assignee:
+            text += ",%s" % truncate_string(self.assignee, 9)
         return text
 
     def sort_key(self):

--- a/ustriage/task.py
+++ b/ustriage/task.py
@@ -45,6 +45,7 @@ class Task:
     SHORTLINK_ROOT = 'LP: #'
     BUG_NUMBER_LENGTH = 7
     AGE = None
+    OLD = None
 
     def __init__(self):
         """Init task object."""
@@ -154,6 +155,8 @@ class Task:
         flags += '+' if self.last_activity_ours else ' '
         if (self.AGE and self.date_last_updated > self.AGE):
             flags += 'U'
+        elif (self.OLD and self.date_last_updated < self.OLD):
+            flags += 'O'
         else:
             flags += ' '
         flags += 'N' if newbug else ' '

--- a/ustriage/ustriage.py
+++ b/ustriage/ustriage.py
@@ -643,6 +643,7 @@ def main(date_range=None, debug=False, open_browser=None,
     logging.info('\'+\': last bug activity is ours')
     if age:
         logging.info('\'U\': Updated in the last %s days', age)
+    logging.info('\'v/V\': SRU - v=>needing verfication; V=>verified')
     logging.info('Please be patient, this can take a few minutes...')
 
     if show_tagged:

--- a/ustriage/ustriage.py
+++ b/ustriage/ustriage.py
@@ -39,6 +39,8 @@ PACKAGE_BLACKLIST = {
 }
 TEAMLPNAME = "ubuntu-server"
 DEFAULTTAG = "server-todo"
+FLAG_RECENT_AGE = 6
+FLAG_OLD_AGE = 90
 
 # See the "Merge Board Coordination" specification for details about these tags
 PACKAGING_TASK_TAGS = [
@@ -841,15 +843,15 @@ def launch():
                         type=int,
                         dest='age',
                         help='Mark bugs touched more recently than this many'
-                             ' days (default disabled in triage, 6 days in '
-                             ' tag/subscription search)')
+                             ' days (default: disabled in triage, %s days in'
+                             ' tag/subscription search)' % FLAG_RECENT_AGE)
     parser.add_argument('--flag-old',
                         default=False,
                         type=int,
                         dest='old',
                         help='Mark bugs not touched for this many days'
-                             ' (default disabled in triage, 90 days in '
-                             ' tag/subscription search)')
+                             ' (default: disabled in triage, %s days in'
+                             ' tag/subscription search)' % FLAG_OLD_AGE)
     parser.add_argument('-S', '--save-tagged-bugs',
                         default=None,
                         dest='filename_save',
@@ -870,11 +872,11 @@ def launch():
                   'end': args.end_date}
 
     if args.age is False and (args.show_subscribed or args.show_tagged):
-        args.age = 6
+        args.age = FLAG_RECENT_AGE
     if args.age is not False:
         Task.AGE = datetime.now(timezone.utc) - timedelta(days=args.age)
     if args.old is False and (args.show_subscribed or args.show_tagged):
-        args.old = 90
+        args.old = FLAG_OLD_AGE
     if args.old is not False:
         Task.OLD = datetime.now(timezone.utc) - timedelta(days=args.old)
 

--- a/ustriage/ustriage.py
+++ b/ustriage/ustriage.py
@@ -641,6 +641,22 @@ def print_subscribed_bugs(lpname, expiration, date_range, open_browser,
                oder_by_date=True, extended=extended)
 
 
+def show_header(lpname, age, old, filename_compare):
+    """Show the dynamic header depending on commandline arguments."""
+    logging.info('Ubuntu Server Triage helper')
+    logging.info('Symbols:')
+    logging.info('\'*\': %s is directly subscribed', lpname)
+    logging.info('\'+\': last bug activity is ours')
+    if age:
+        logging.info('\'U\': Updated in the last %s days', age)
+    if old:
+        logging.info('\'O\': Not updated in the last %s days', old)
+    if filename_compare:
+        logging.info('\'N\': New bug compared to %s', filename_compare)
+    logging.info('\'v/V\': SRU - v=>needing verfication; V=>verified')
+    logging.info('Please be patient, this can take a few minutes...')
+
+
 def main(date_range=None, debug=False, open_browser=None,
          lpname=TEAMLPNAME, bugsubscriber=False, shortlinks=True,
          activitysubscribernames=None, expiration=None,
@@ -661,18 +677,7 @@ def main(date_range=None, debug=False, open_browser=None,
     else:
         activitysubscribers = []
 
-    logging.info('Ubuntu Server Triage helper')
-    logging.info('Symbols:')
-    logging.info('\'*\': %s is directly subscribed', lpname)
-    logging.info('\'+\': last bug activity is ours')
-    if age:
-        logging.info('\'U\': Updated in the last %s days', age)
-    if old:
-        logging.info('\'O\': Not updated in the last %s days', old)
-    if filename_compare:
-        logging.info('\'N\': New bug compared to %s', filename_compare)
-    logging.info('\'v/V\': SRU - v=>needing verfication; V=>verified')
-    logging.info('Please be patient, this can take a few minutes...')
+    show_header(lpname, age, old, filename_compare)
 
     if show_tagged:
         print_tagged_bugs(lpname, None, None, open_browser['triage'],

--- a/ustriage/ustriage.py
+++ b/ustriage/ustriage.py
@@ -311,10 +311,20 @@ def print_bugs(tasks, open_in_browser=False, shortlinks=True, blacklist=None,
             former_bugs = yaml.safe_load(comparebugs)
 
     reportedbugs = []
+    reported_further_tasks = False
     for task in sorted_filtered_tasks:
         if task.number in reportedbugs:
-            print(task.compose_dup(shortlinks=shortlinks, extended=extended))
+            if reported_further_tasks:
+                print(", ", end='')
+            else:
+                print("Also: ", end='')
+            print("[%s]" % task.compose_dup(extended=extended), end='')
+            reported_further_tasks = True
             continue
+        if reported_further_tasks:
+            # Add newline after additional tasks are complete
+            print()
+        reported_further_tasks = False
 
         newbug = filename_compare and task.number not in former_bugs
         print(task.compose_pretty(shortlinks=shortlinks, extended=extended,
@@ -329,6 +339,10 @@ def print_bugs(tasks, open_in_browser=False, shortlinks=True, blacklist=None,
                 opened = True
                 time.sleep(5)
         reportedbugs.append(task.number)
+
+    if reported_further_tasks:
+        # Add newline after additional tasks are complete
+        print()
 
     if filename_save is not None:
         with open(filename_save, "w", encoding='utf-8') as savebugs:

--- a/ustriage/ustriage.py
+++ b/ustriage/ustriage.py
@@ -271,6 +271,24 @@ def parse_dates(start, end=None):
     return start, end
 
 
+def handle_files(filename_save, filename_compare, reportedbugs, former_bugs,
+                 shortlinks, extended):
+    """Handle saving and comparing to saved lists of bugs."""
+    if filename_save is not None:
+        with open(filename_save, "w", encoding='utf-8') as savebugs:
+            yaml.dump(reportedbugs, stream=savebugs)
+        print("Saved reported bugs in %s" % filename_save)
+
+    if filename_compare is not None:
+        closed_bugs = [x for x in former_bugs if x not in reportedbugs]
+        logging.info('')
+        logging.info('---')
+        logging.info("Bugs gone compared with %s:", filename_compare)
+        gone_tasks = bugs_to_tasks(closed_bugs)
+        print_bugs(gone_tasks, open_in_browser=False,
+                   shortlinks=shortlinks, is_sorted=True, extended=extended)
+
+
 def print_bugs(tasks, open_in_browser=False, shortlinks=True, blacklist=None,
                limit_subscribed=None, oder_by_date=False, is_sorted=False,
                extended=False, filename_save=None, filename_compare=None):
@@ -344,19 +362,8 @@ def print_bugs(tasks, open_in_browser=False, shortlinks=True, blacklist=None,
         # Add newline after additional tasks are complete
         print()
 
-    if filename_save is not None:
-        with open(filename_save, "w", encoding='utf-8') as savebugs:
-            yaml.dump(reportedbugs, stream=savebugs)
-        print("Saved reported bugs in %s" % filename_save)
-
-    if filename_compare is not None:
-        closed_bugs = [x for x in former_bugs if x not in reportedbugs]
-        logging.info('')
-        logging.info('---')
-        logging.info("Bugs gone compared with %s:", filename_compare)
-        gone_tasks = bugs_to_tasks(closed_bugs)
-        print_bugs(gone_tasks, open_in_browser=False,
-                   shortlinks=shortlinks, is_sorted=True, extended=extended)
+    handle_files(filename_save, filename_compare, reportedbugs, former_bugs,
+                 shortlinks=shortlinks, extended=extended)
 
 
 def last_activity_ours(task, activitysubscribers):

--- a/ustriage/ustriage.py
+++ b/ustriage/ustriage.py
@@ -646,7 +646,7 @@ def main(date_range=None, debug=False, open_browser=None,
          activitysubscribernames=None, expiration=None,
          show_no_triage=False, show_tagged=False, show_subscribed=False,
          limit_subscribed=None, blacklist=None, tags=None,
-         extended=False, age=False,
+         extended=False, age=False, old=False,
          filename_save=None, filename_compare=None):
     """Connect to Launchpad, get range of bugs, print 'em."""
     if tags is None:
@@ -667,6 +667,8 @@ def main(date_range=None, debug=False, open_browser=None,
     logging.info('\'+\': last bug activity is ours')
     if age:
         logging.info('\'U\': Updated in the last %s days', age)
+    if old:
+        logging.info('\'O\': Not updated in the last %s days', old)
     if filename_compare:
         logging.info('\'N\': New bug compared to %s', filename_compare)
     logging.info('\'v/V\': SRU - v=>needing verfication; V=>verified')
@@ -834,7 +836,14 @@ def launch():
                         type=int,
                         dest='age',
                         help='Mark bugs touched more recently than this many'
-                             ' days (default disabled in triage, 7 days in '
+                             ' days (default disabled in triage, 6 days in '
+                             ' tag/subscription search)')
+    parser.add_argument('--flag-old',
+                        default=False,
+                        type=int,
+                        dest='old',
+                        help='Mark bugs not touched for this many days'
+                             ' (default disabled in triage, 90 days in '
                              ' tag/subscription search)')
     parser.add_argument('-S', '--save-tagged-bugs',
                         default=None,
@@ -856,16 +865,21 @@ def launch():
                   'end': args.end_date}
 
     if args.age is False and (args.show_subscribed or args.show_tagged):
-        args.age = 7
+        args.age = 6
     if args.age is not False:
         Task.AGE = datetime.now(timezone.utc) - timedelta(days=args.age)
+    if args.old is False and (args.show_subscribed or args.show_tagged):
+        args.old = 90
+    if args.old is not False:
+        Task.OLD = datetime.now(timezone.utc) - timedelta(days=args.old)
 
     main(date_range, args.debug, open_browser,
          args.lpname, args.bugsubscriber, not args.fullurls,
          args.activitysubscribers, expiration, args.show_no_triage,
          args.show_tagged, args.show_subscribed, args.limit_subscribed,
          blacklist=None if args.no_blacklist else PACKAGE_BLACKLIST,
-         tags=[args.tag], extended=args.extended_format, age=args.age,
+         tags=[args.tag], extended=args.extended_format,
+         age=args.age, old=args.old,
          filename_save=args.filename_save,
          filename_compare=args.filename_compare)
 

--- a/ustriage/ustriage.py
+++ b/ustriage/ustriage.py
@@ -643,6 +643,8 @@ def main(date_range=None, debug=False, open_browser=None,
     logging.info('\'+\': last bug activity is ours')
     if age:
         logging.info('\'U\': Updated in the last %s days', age)
+    if filename_compare:
+        logging.info('\'N\': New bug compared to %s', filename_compare)
     logging.info('\'v/V\': SRU - v=>needing verfication; V=>verified')
     logging.info('Please be patient, this can take a few minutes...')
 


### PR DESCRIPTION
There are some optimizations that can be done to improve our regular experience with this.
This PR does not yet tackle checking the upload queue, but everything else we mentioned is covered already (and probably gets us 90% there at 10% of the price).

Overall this PR does:
- add a flag if in some stage of SRU verification
- shorten the listing of additional task
- add the missing header for the "new" flags