### PR TITLE
Fix type of open_browser

### DIFF
--- a/ustriage/ustriage.py
+++ b/ustriage/ustriage.py
@@ -638,7 +638,7 @@ def print_subscribed_bugs(lpname, expiration, date_range, open_browser,
         tags=tags,
         status=OPEN_BUG_STATUSES,
     )
-    print_bugs(bugs, open_browser['exp'], shortlinks,
+    print_bugs(bugs, open_browser, shortlinks,
                blacklist=blacklist, limit_subscribed=limit_subscribed,
                oder_by_date=True, extended=extended)
 


### PR DESCRIPTION
This is sometimes a dict, and sometimes an int. In this case, it needs
to be a dict because the callee looks inside it as a dict.