### PR TITLE
Check a team's participants rather than members

### DIFF
--- a/ustriage/ustriage.py
+++ b/ustriage/ustriage.py
@@ -674,7 +674,7 @@ def main(date_range=None, debug=False, open_browser=None,
                         level=logging.DEBUG if debug else logging.INFO)
     if activitysubscribernames:
         activitysubscribers = (
-            launchpad.people[activitysubscribernames].members
+            launchpad.people[activitysubscribernames].participants
         )
     else:
         activitysubscribers = []


### PR DESCRIPTION
The Ubuntu Foundations team would like to use our public team (~ubuntu-foundations-team) but flag activity from the Canonical Foundations Team (~canonical-foundations which is a member of the Ubuntu Foundations team) and direct members of the Ubuntu Foundations team. This change does that by switching from members, direct members only, to participants which is "all direct and indirect people and teams".

https://api.launchpad.net/devel/#person