### PR TITLE
ustriage: Avoid uninitialized use

### DIFF
--- a/ustriage/ustriage.py
+++ b/ustriage/ustriage.py
@@ -354,10 +354,8 @@ def print_bugs(tasks, open_in_browser=0, shortlinks=True, blacklist=None,
             reverse=oder_by_date
         )
 
-    if filename_compare is not None:
-        former_bugs = load_former_bugs(filename_compare)
-    if filename_postponed is not None:
-        postponed_bugs = load_postponed_bugs(filename_postponed)
+    former_bugs = load_former_bugs(filename_compare)
+    postponed_bugs = load_postponed_bugs(filename_postponed)
 
     logging.info('Found %s bugs\n', len(sorted_filtered_tasks))
     if len(sorted_filtered_tasks) == 0:


### PR DESCRIPTION
The recent changes will break the tool if not used with saved files. The loading functions check the file and will properly return an empty list, therefore we can call them unconditionally.