### PR TITLE
Update to base22

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: ustriage
 summary: Output Ubuntu Server Launchpad bugs for triage
-base: core18
+base: core22
 type: app
 description: |
   Connect to Launchpad and collect Ubuntu Server bugs for triage.

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -13,6 +13,7 @@ confinement: strict
 environment:
     LC_ALL: C.UTF-8
     LANG: C.UTF-8
+    PYTHONPATH: $SNAP/usr/lib/python3/dist-packages:$SNAP/usr/lib/python3.10/dist-packages
 
 apps:
     ustriage:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -8,7 +8,6 @@ description: |
   filtering based on various options.
 
 version: git
-version-script: git rev-parse --short HEAD
 grade: stable
 confinement: strict
 environment:


### PR DESCRIPTION
Among just making it more modern this fixes authentication issues of core18 openssl/python combination with launchpad.


Issue was like:
```
  ssl.SSLError: [SSL: TLSV1_ALERT_PROTOCOL_VERSION] tlsv1 alert protocol version (_ssl.c:852)
```
