### PR TITLE
Add missing install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,5 +28,5 @@ setup(name='ustriage',
       entry_points={
           'console_scripts': ['ustriage=ustriage.ustriage:launch']
       },
-      install_requires=[],
+      install_requires=['pyyaml', 'python-dateutil'],
       zip_safe=False)


### PR DESCRIPTION
To run ustriage from the development branch instead of using a snap, one needs to install it locally (e.g., using pip) or ensure all the required dependencies are available. This patch declares such dependencies in the setup.py file.

While some dependencies are still missing, they (the missing dependencies) are debian/ubuntu specific packages usually not available (or out-of-date) in PyPI. We should use their deb versions from the user's system.