### PR TITLE
Generate json output

### DIFF
--- a/ustriage/task.py
+++ b/ustriage/task.py
@@ -96,7 +96,13 @@ def get_upload_source_urls(upload):
 
 
 class Task:
-    """Our representation of a Launchpad task."""
+    """Launchpad Bug Task.
+
+    Encapsulates the Launchpad representation of a task for a bug
+    reported against a source package.   A bug task tracks the bug's
+    state in different distribution releases, related packages, and
+    remote bug trackers.
+    """
 
     LONG_URL_ROOT = 'https://pad.lv/'
     SHORTLINK_ROOT = 'LP: #'
@@ -114,6 +120,31 @@ class Task:
         # Whether the last activity was by us
         self.last_activity_ours = None
         self.obj = None
+
+    def __str__(self):
+        """Return a human-readable summary of the object.
+
+        :rtype: str
+        :returns: Printable summary of the object.
+        """
+        return f'LP #{self.number:8d} {self.status:12s} {self.title}'
+
+    @lru_cache
+    def to_dict(self):
+        """Return a basic dict structure of the Bug Task's data."""
+        return {
+            "url": self.url,
+            "shortlink": self.shortlink,
+            "number": self.number,
+            "title": self.title,
+            "short_title": self.short_title,
+
+            "source_package": self.src,
+            "importance": self.importance,
+            "status": self.status,
+            "tags": self.tags,
+            "assignee": self.assignee,
+        }
 
     @staticmethod
     def create_from_launchpadlib_object(obj, **kwargs):

--- a/ustriage/task.py
+++ b/ustriage/task.py
@@ -113,13 +113,28 @@ class Task:
     NOWORK_BUG_STATUSES = []
     OPEN_BUG_STATUSES = []
 
-    def __init__(self):
+    def __init__(self, lp_task=None):
         """Init task object."""
         # Whether the team is subscribed to the bug
         self.subscribed = None
         # Whether the last activity was by us
         self.last_activity_ours = None
-        self.obj = None
+
+        if lp_task:
+            # Some information can be extracted from the task URL itself
+            # without requiring a round-trip to Launchpad
+            task_elements = str(lp_task).split('/')
+            self.distro = task_elements[4]
+            self.source_package_name = task_elements[-3]
+            self.series = task_elements[5]
+            if self.series == '+source':
+                self.series = '-devel'
+            self.obj = lp_task
+        else:
+            self.distro = None
+            self.source_package_name = None
+            self.series = None
+            self.obj = None
 
     def __str__(self):
         """Return a human-readable summary of the object.
@@ -139,7 +154,10 @@ class Task:
             "title": self.title,
             "short_title": self.short_title,
 
+            "distro": self.distro,
             "source_package": self.src,
+            "source_package_name": self.source_package_name,
+            "series": self.series,
             "importance": self.importance,
             "status": self.status,
             "tags": self.tags,

--- a/ustriage/ustriage.py
+++ b/ustriage/ustriage.py
@@ -742,7 +742,11 @@ def main(date_range=None, debug=False, open_browser=None,
                 tags=tags + ["-bot-stop-nagging"],
                 status=TRACKED_BUG_STATUSES
             )
-            json.dump(bugs, sys.stdout, indent=4, default=str)
+            json.dump(
+                [bug.to_dict() for bug in bugs],
+                sys.stdout,
+                indent=4,
+                default=str)
         else:
             print_tagged_bugs(lpname, None, None, open_browser['triage'],
                               shortlinks, blacklist, activitysubscribers,

--- a/ustriage/ustriage.py
+++ b/ustriage/ustriage.py
@@ -363,7 +363,7 @@ def load_postponed_bugs(filename_postponed):
 
 
 def print_bugs(tasks, open_in_browser=0, shortlinks=True, blacklist=None,
-               limit_subscribed=None, oder_by_date=False, is_sorted=False,
+               limit_subscribed=None, order_by_date=False, is_sorted=False,
                extended=False, filename_save=None, filename_compare=None,
                filename_postponed=None):
     """Print the tasks in a clean-ish format."""
@@ -374,8 +374,8 @@ def print_bugs(tasks, open_in_browser=0, shortlinks=True, blacklist=None,
     else:
         sorted_filtered_tasks = sorted(
             (t for t in tasks if t.src not in blacklist),
-            key=(Task.sort_date if oder_by_date else Task.sort_key),
-            reverse=oder_by_date
+            key=(Task.sort_date if order_by_date else Task.sort_key),
+            reverse=order_by_date
         )
 
     former_bugs = load_former_bugs(filename_compare)
@@ -394,14 +394,14 @@ def print_bugs(tasks, open_in_browser=0, shortlinks=True, blacklist=None,
         logging.info('# Recent tasks #')
         print_bugs(sorted_filtered_tasks[:limit_subscribed],
                    open_in_browser, shortlinks, limit_subscribed=None,
-                   oder_by_date=False, is_sorted=True, extended=extended)
+                   order_by_date=False, is_sorted=True, extended=extended)
         logging.info('---------------------------------------------------')
         logging.info('# Oldest tasks #')
         # https://github.com/PyCQA/pylint/issues/1472
         # pylint: disable=invalid-unary-operand-type
         print_bugs(sorted_filtered_tasks[-limit_subscribed:],
                    open_in_browser, shortlinks, limit_subscribed=None,
-                   oder_by_date=False, is_sorted=True, extended=extended)
+                   order_by_date=False, is_sorted=True, extended=extended)
         return
 
     reportedbugs = []
@@ -704,7 +704,7 @@ def print_subscribed_bugs(lpname, expiration, date_range, open_browser,
     )
     print_bugs(bugs, open_browser, shortlinks,
                blacklist=blacklist, limit_subscribed=limit_subscribed,
-               oder_by_date=True, extended=extended)
+               order_by_date=True, extended=extended)
 
 
 def main(date_range=None, debug=False, open_browser=None,


### PR DESCRIPTION
Adds preliminary JSON support to ustriage.  This adds a --json option which can be used when generating the housekeeping report.

JSON support generally, for the daily triage report and other invocations of ustriage will be added in a separate branch.  That will require more extensive refactoring and is beyond the scope of what this branch aims for.

To test this, I've run the following three commands on each commit in the branch:

  $ tox
  $ python3 -m ustriage
  $ python3 -m ustriage --no-show-triage --extended --show-tagged --tag server-todo --json

I've verified 1. tox passes on all commits, 2. the triage reports generate byte-identical output, and 3. the json output is loadable as a valid JSON document (see check-json in housekeeping-tools).