### PR TITLE
Avoid activity check crash when no activity found

### DIFF
--- a/ustriage/ustriage.py
+++ b/ustriage/ustriage.py
@@ -468,7 +468,11 @@ def last_activity_ours(task, activitysubscribers):
                 continue
             raise
 
-    most_recent_activity = activity_list.pop()
+    try:
+        most_recent_activity = activity_list.pop()
+    except IndexError:
+        # No activity found - assume we did not touch it last
+        return False
 
     # Consider anything within an hour of the last activity or message as
     # part of the same action


### PR DESCRIPTION
Some updates on launchpad bugs may not count as new activity. When these happen, ustriage may not find any recent activity, causing a crash when checking if the activity was ours. Fix the crash by assuming we were not the last to touch it.